### PR TITLE
Fixes for upcoming pekwm-0.2.0 release

### DIFF
--- a/theme
+++ b/theme
@@ -26,6 +26,10 @@ Require {
 	Templates = "True"
 }
 
+Background {
+	Texture = "Solid #bebebe"
+}
+
 Define = "BaseDecor" {
 	Height = "22"
 	HeightAdapt = "False"
@@ -101,6 +105,7 @@ Define = "BaseBorder" {
 }
 
 Define = "EmptyDecor" {
+	Height = "0"
 	Focused = "Empty"
 	Unfocused = "Empty"
 	Tab {


### PR DESCRIPTION
Add Background to theme and set height of the title to 0 on the
EmptyDecor to avoid default height value (and garbage being rendered).